### PR TITLE
lazy init sqlite3

### DIFF
--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -8,7 +8,6 @@ See license information at the bottom of this file
 
 
 from __future__ import division
-import sqlite3
 import datetime
 import re
 import os
@@ -93,6 +92,7 @@ if __name__ == "__main__":
             version = (select max(version) from wiki where name = w.name)
 '''
 
+    import sqlite3
     conn = sqlite3.connect('../trac.db')
     result = conn.execute(SQL)
     for row in result:


### PR DESCRIPTION
sqlite3 not normally required if using direct mode

i couldn't get sqlite3 installed in gitlab-omnibus package (couldn't figure out which package to `pip install`) and sqlite3 not needed in this project (it's for accessing `trac.db` directly in wiki module)
