### PR TITLE
New options and bugfixes

### DIFF
--- a/gitlab_direct/Connection.py
+++ b/gitlab_direct/Connection.py
@@ -145,7 +145,7 @@ class Connection(object):
             if not os.path.exists(directory):
                 os.makedirs(directory)
             path = os.path.join(directory, note.attachment)
-            file = open(path,"wb")
+            file = open(path.encode('utf-8'),"wb")
             file.write(binary_attachment)
             file.close()
 

--- a/gitlab_direct/Connection.py
+++ b/gitlab_direct/Connection.py
@@ -110,6 +110,8 @@ class Connection(object):
         )
         event.save()
         for title in set(new_issue.labels.split(',')):
+            if (title == ''):
+                continue
             try:
                 label = Labels.get((Labels.title == title) & (Labels.project == dest_project_id))
             except:

--- a/migrate.cfg.example
+++ b/migrate.cfg.example
@@ -73,4 +73,27 @@ target-directory: /tmp/test.wiki/
 # migrate: yes
 
 # If defined, import only these issues
-#only_issues: [ 509, 561, 564, 626, 631, 792, 830]
+# only_issues: [ 509, 561, 564, 626, 631, 792, 830]
+
+# If defined, do not import these issues
+# blacklist_issues: [ 268, 843 ]
+
+# Add a label to all migrated issues
+# add_label: Websites
+
+# Trac component to migrate issues from
+component_filter: [
+    u'Vorbis Core - documentation',
+    u'Vorbis Core - libvorbis',
+    u'Vorbis Core - libvorbisenc',
+    u'Vorbis Core - libvorbisfile'
+    ]
+
+# Migrate keywords
+migrate_keywords: no
+
+# Migrate milestones
+migrate_milestones: no
+
+# Add the trac component as label to the Gitlab issue
+add_component_as_label: no

--- a/migrate.py
+++ b/migrate.py
@@ -152,8 +152,9 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
             continue
 
         src_ticket_data = src_ticket[3]
-
-        src_ticket_priority = src_ticket_data['priority']
+        src_ticket_priority = 'normal'
+        if 'priority' in src_ticket_data:
+            src_ticket_priority = src_ticket_data['priority']
         src_ticket_resolution = src_ticket_data['resolution']
         # src_ticket_severity = src_ticket_data['severity']
         src_ticket_status = src_ticket_data['status']

--- a/migrate.py
+++ b/migrate.py
@@ -83,6 +83,7 @@ blacklist_issues = None
 if config.has_option('issues', 'blacklist_issues'):
     blacklist_issues = ast.literal_eval(config.get('issues', 'blacklist_issues'))
 must_convert_wiki = config.getboolean('wiki', 'migrate')
+migrate_keywords = config.getboolean('issues', 'migrate_keywords')
 
 pattern_changeset = r'(?sm)In \[changeset:"([^"/]+?)(?:/[^"]+)?"\]:\n\{\{\{(\n#![^\n]+)?\n(.*?)\n\}\}\}'
 matcher_changeset = re.compile(pattern_changeset)
@@ -157,6 +158,7 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         # src_ticket_severity = src_ticket_data['severity']
         src_ticket_status = src_ticket_data['status']
         src_ticket_component = src_ticket_data.get('component', '')
+        src_ticket_keywords = src_ticket_data['keywords']
 
         new_labels = []
         if src_ticket_priority == 'high':
@@ -193,6 +195,9 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         if src_ticket_component != '':
             for component in src_ticket_component.split(','):
                 new_labels.append(component.strip())
+        if src_ticket_keywords != '' and migrate_keywords:
+            for keyword in src_ticket_keywords.split(','):
+                new_labels.append(keyword.strip())
 
         print("new labels: %s" % new_labels)
 

--- a/migrate.py
+++ b/migrate.py
@@ -79,6 +79,9 @@ must_convert_issues = config.getboolean('issues', 'migrate')
 only_issues = None
 if config.has_option('issues', 'only_issues'):
     only_issues = ast.literal_eval(config.get('issues', 'only_issues'))
+blacklist_issues = None
+if config.has_option('issues', 'blacklist_issues'):
+    blacklist_issues = ast.literal_eval(config.get('issues', 'blacklist_issues'))
 must_convert_wiki = config.getboolean('wiki', 'migrate')
 
 pattern_changeset = r'(?sm)In \[changeset:"([^"/]+?)(?:/[^"]+)?"\]:\n\{\{\{(\n#![^\n]+)?\n(.*?)\n\}\}\}'
@@ -113,7 +116,7 @@ def get_dest_milestone_id(dest, dest_project_id,milestone_name):
         raise ValueError("Milestone '%s' of project '%s' not found" % (milestone_name, dest_project_name))
     return dest_milestone_id["id"]
 
-def convert_issues(source, dest, dest_project_id, only_issues=None):
+def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_issues=None):
     if overwrite and (method == 'direct'):
         dest.clear_issues(dest_project_id)
 
@@ -142,6 +145,9 @@ def convert_issues(source, dest, dest_project_id, only_issues=None):
         src_ticket_id = src_ticket[0]
         if only_issues and src_ticket_id not in only_issues:
             print("SKIP unwanted ticket #%s" % src_ticket_id)
+            continue
+        if blacklist_issues and src_ticket_id in blacklist_issues:
+            print("SKIP blacklisted ticket #%s" % src_ticket_id)
             continue
 
         src_ticket_data = src_ticket[3]
@@ -301,7 +307,7 @@ if __name__ == "__main__":
     dest_project_id = get_dest_project_id(dest, dest_project_name)
 
     if must_convert_issues:
-        convert_issues(source, dest, dest_project_id, only_issues=only_issues)
+        convert_issues(source, dest, dest_project_id, only_issues=only_issues, blacklist_issues=blacklist_issues)
 
     if must_convert_wiki:
         convert_wiki(source, dest, dest_project_id)

--- a/migrate.py
+++ b/migrate.py
@@ -156,7 +156,7 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         if 'priority' in src_ticket_data:
             src_ticket_priority = src_ticket_data['priority']
         src_ticket_resolution = src_ticket_data['resolution']
-        # src_ticket_severity = src_ticket_data['severity']
+        src_ticket_severity = src_ticket_data['severity']
         src_ticket_status = src_ticket_data['status']
         src_ticket_component = src_ticket_data.get('component', '')
         src_ticket_keywords = src_ticket_data['keywords']
@@ -183,12 +183,12 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         elif src_ticket_resolution == 'worksforme':
             new_labels.append('works for me')
 
-        # if src_ticket_severity == 'high':
-        #     new_labels.append('critical')
-        # elif src_ticket_severity == 'medium':
-        #     pass
-        # elif src_ticket_severity == 'low':
-        #     new_labels.append("minor")
+        if src_ticket_severity == 'high':
+            new_labels.append('critical')
+        elif src_ticket_severity == 'medium':
+            pass
+        elif src_ticket_severity == 'low':
+            new_labels.append("minor")
 
         # Current ticket types are: enhancement, defect, compilation, performance, style, scientific, task, requirement
         # new_labels.append(src_ticket_type)

--- a/migrate.py
+++ b/migrate.py
@@ -268,9 +268,14 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
                 # The attachment will be described in the next change!
                 is_attachment = True
                 attachment = change
-            if (change_type == "comment") and change[4] != '':
+            if (change_type == "comment"):
+                desc = change[4]
+                if (desc == '' and is_attachment == False):
+                    continue
+                if (desc != ''):
+                    desc = fix_wiki_syntax(change[4])
                 note = Notes(
-                    note=trac2down.convert(fix_wiki_syntax(change[4]), '/issues/', False)
+                    note=trac2down.convert(desc, '/issues/', False)
                 )
                 binary_attachment = None
                 if (method == 'direct'):

--- a/migrate.py
+++ b/migrate.py
@@ -255,7 +255,7 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
 
         if 'milestone' in src_ticket_data:
             milestone = src_ticket_data['milestone']
-            if milestone and milestone_map_id[milestone]:
+            if milestone and milestone in milestone_map_id:
                 new_issue.milestone = milestone_map_id[milestone]
         new_ticket = dest.create_issue(dest_project_id, new_issue)
         # new_ticket_id  = new_ticket.id

--- a/migrate.py
+++ b/migrate.py
@@ -84,6 +84,7 @@ if config.has_option('issues', 'blacklist_issues'):
     blacklist_issues = ast.literal_eval(config.get('issues', 'blacklist_issues'))
 must_convert_wiki = config.getboolean('wiki', 'migrate')
 migrate_keywords = config.getboolean('issues', 'migrate_keywords')
+migrate_milestones = config.getboolean('issues', 'migrate_milestones')
 add_component_as_label = config.getboolean('issues', 'add_component_as_label')
 component_filter = None
 if config.has_option('issues', 'component_filter'):
@@ -129,20 +130,22 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         dest.clear_issues(dest_project_id)
 
     milestone_map_id={}
-    for milestone_name in source.ticket.milestone.getAll():
-        milestone = source.ticket.milestone.get(milestone_name)
-        print(milestone)
-        new_milestone = Milestones(
-            description = trac2down.convert(fix_wiki_syntax(milestone['description']), '/milestones/', False),
-            title = milestone['name'],
-            state = 'active' if str(milestone['completed']) == '0'  else 'closed'
-        )
-        if method == 'direct':
-            new_milestone.project = dest_project_id
-        if milestone['due']:
-            new_milestone.due_date = convert_xmlrpc_datetime(milestone['due'])
-        new_milestone = dest.create_milestone(dest_project_id, new_milestone)
-        milestone_map_id[milestone_name] = new_milestone.id
+
+    if migrate_milestones:
+        for milestone_name in source.ticket.milestone.getAll():
+            milestone = source.ticket.milestone.get(milestone_name)
+            print(milestone)
+            new_milestone = Milestones(
+                description = trac2down.convert(fix_wiki_syntax(milestone['description']), '/milestones/', False),
+                title = milestone['name'],
+                state = 'active' if str(milestone['completed']) == '0'  else 'closed'
+            )
+            if method == 'direct':
+                new_milestone.project = dest_project_id
+            if milestone['due']:
+                new_milestone.due_date = convert_xmlrpc_datetime(milestone['due'])
+            new_milestone = dest.create_milestone(dest_project_id, new_milestone)
+            milestone_map_id[milestone_name] = new_milestone.id
 
     get_all_tickets = xmlrpclib.MultiCall(source)
 

--- a/migrate.py
+++ b/migrate.py
@@ -84,6 +84,9 @@ if config.has_option('issues', 'blacklist_issues'):
     blacklist_issues = ast.literal_eval(config.get('issues', 'blacklist_issues'))
 must_convert_wiki = config.getboolean('wiki', 'migrate')
 migrate_keywords = config.getboolean('issues', 'migrate_keywords')
+component_filter = None
+if config.has_option('issues', 'component_filter'):
+    component_filter = ast.literal_eval(config.get('issues', 'component_filter'))
 add_label = None
 if config.has_option('issues', 'add_label'):
             add_label = config.get('issues', 'add_label')
@@ -163,6 +166,8 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         src_ticket_status = src_ticket_data['status']
         src_ticket_component = src_ticket_data.get('component', '')
         src_ticket_keywords = src_ticket_data['keywords']
+        if (component_filter and src_ticket_component not in component_filter):
+            continue
 
         new_labels = []
         if src_ticket_priority == 'high':

--- a/migrate.py
+++ b/migrate.py
@@ -84,6 +84,9 @@ if config.has_option('issues', 'blacklist_issues'):
     blacklist_issues = ast.literal_eval(config.get('issues', 'blacklist_issues'))
 must_convert_wiki = config.getboolean('wiki', 'migrate')
 migrate_keywords = config.getboolean('issues', 'migrate_keywords')
+add_label = None
+if config.has_option('issues', 'add_label'):
+            add_label = config.get('issues', 'add_label')
 
 pattern_changeset = r'(?sm)In \[changeset:"([^"/]+?)(?:/[^"]+)?"\]:\n\{\{\{(\n#![^\n]+)?\n(.*?)\n\}\}\}'
 matcher_changeset = re.compile(pattern_changeset)
@@ -196,6 +199,9 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         if src_ticket_component != '':
             for component in src_ticket_component.split(','):
                 new_labels.append(component.strip())
+        if add_label:
+            new_labels.append(add_label)
+
         if src_ticket_keywords != '' and migrate_keywords:
             for keyword in src_ticket_keywords.split(','):
                 new_labels.append(keyword.strip())

--- a/migrate.py
+++ b/migrate.py
@@ -84,6 +84,7 @@ if config.has_option('issues', 'blacklist_issues'):
     blacklist_issues = ast.literal_eval(config.get('issues', 'blacklist_issues'))
 must_convert_wiki = config.getboolean('wiki', 'migrate')
 migrate_keywords = config.getboolean('issues', 'migrate_keywords')
+add_component_as_label = config.getboolean('issues', 'add_component_as_label')
 component_filter = None
 if config.has_option('issues', 'component_filter'):
     component_filter = ast.literal_eval(config.get('issues', 'component_filter'))
@@ -201,9 +202,10 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
         # Current ticket types are: enhancement, defect, compilation, performance, style, scientific, task, requirement
         # new_labels.append(src_ticket_type)
 
-        if src_ticket_component != '':
+        if add_component_as_label and src_ticket_component != '':
             for component in src_ticket_component.split(','):
                 new_labels.append(component.strip())
+
         if add_label:
             new_labels.append(add_label)
 

--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -26,12 +26,12 @@ def convert(text, base_path, multilines=True):
     if multilines:
         text = re.sub(r'^\S[^\n]+([^=-_|])\n([^\s`*0-9#=->-_|])', r'\1 \2', text)
 
-    text = re.sub(r'(?m)^======\s+(.*?)\s+======$', r'###### \1', text)
-    text = re.sub(r'(?m)^=====\s+(.*?)\s+=====$', r'##### \1', text)
-    text = re.sub(r'(?m)^====\s+(.*?)\s+====$', r'#### \1', text)
-    text = re.sub(r'(?m)^===\s+(.*?)\s+===$', r'### \1', text)
-    text = re.sub(r'(?m)^==\s+(.*?)\s+==$', r'## \1', text)
-    text = re.sub(r'(?m)^=\s+(.*?)\s+=$', r'# \1', text)
+    text = re.sub(r'(?m)^======\s+(.*?)\s+======$', r'\n###### \1', text)
+    text = re.sub(r'(?m)^=====\s+(.*?)\s+=====$', r'\n##### \1', text)
+    text = re.sub(r'(?m)^====\s+(.*?)\s+====$', r'\n#### \1', text)
+    text = re.sub(r'(?m)^===\s+(.*?)\s+===$', r'\n### \1', text)
+    text = re.sub(r'(?m)^==\s+(.*?)\s+==$', r'\n## \1', text)
+    text = re.sub(r'(?m)^=\s+(.*?)\s+=$', r'\n# \1', text)
     text = re.sub(r'^             * ', r'****', text)
     text = re.sub(r'^         * ', r'***', text)
     text = re.sub(r'^     * ', r'**', text)


### PR DESCRIPTION
This PR contains various commits that fix some bugs:

- Fix error if milestone_map_id does not contain the milestone
- Fix encoding error when writing some attachments
- Fix missing newlines in Trac2Down conversion of headings
- Fix migration of ticket priorities
- Fix critical issue where attachments without a comment would be added to the wrong comment on Gitlab, therefore associated to the wrong user

Additionally it adds the following new options:

- Issue blacklist (`blacklist_issues`) to not migrate specific issues
- Adding label (`add_label`) to add a label to all migrated issues
- Component filter (`component_filter`) to only migrate issues that belong to one of the given components
- Toggle keyword migration (`migrate_keywords`) to enable or disable keyword migration
- Toggle milestone migration (`migrate_milestones`) to enable or disable milestone migration
- Toggle adding component as labels (`add_component_as_label`)  to enable or disable that trac components would be added as labels to the issue
