### PR TITLE
Markdown fixes

### DIFF
--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -68,7 +68,7 @@ def convert(text, base_path, multilines=True):
 
 def save_file(text, name, version, date, author, directory):
     folders = name.rsplit("/", 1)
-    if not os.path.exists("%s%s" % (directory, folders[0])):
+    if len(folders) > 1 and not os.path.exists("%s%s" % (directory, folders[0])):
         os.makedirs("%s%s" % (directory, folders[0]))
     fp = open('%s%s.markdown' % (directory, name), 'w')
     # print >>fp, '<!-- Name: %s -->' % name

--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -13,6 +13,8 @@ import re
 import os
 from io import open
 
+meta_header = True
+
 
 def convert(text, base_path, multilines=True):
     text = re.sub('\r\n', '\n', text)
@@ -71,10 +73,14 @@ def save_file(text, name, version, date, author, directory):
     if len(folders) > 1 and not os.path.exists("%s%s" % (directory, folders[0])):
         os.makedirs("%s%s" % (directory, folders[0]))
     fp = open('%s%s.markdown' % (directory, name), 'w')
-    # print >>fp, '<!-- Name: %s -->' % name
-    # print >>fp, '<!-- Version: %d -->' % version
-    # print >>fp, '<!-- Last-Modified: %s -->' % date
-    # print >>fp, '<!-- Author: %s -->' % author
+
+    if meta_header:
+        fp.write( unicode('<!-- Name: %s -->\n' % name) )
+        fp.write( unicode('<!-- Version: %d -->\n' % version) )
+        fp.write( unicode('<!-- Last-Modified: %s -->\n' % date) )
+        fp.write( unicode('<!-- Author: %s -->\n' % author) )
+        fp.write( unicode('\n') )
+
     fp.write(unicode(text))
     fp.close()
 

--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -14,7 +14,10 @@ import re
 import os
 from io import open
 
-meta_header = True
+# Config Start
+meta_header = True              # whether to include the wiki pages' meta data at the top of the markdown
+markdown_extension = 'markdown' # file extension to use for the generated markdown files
+# Config End
 
 
 def convert(text, base_path, multilines=True):
@@ -73,7 +76,7 @@ def save_file(text, name, version, date, author, directory):
     folders = name.rsplit("/", 1)
     if len(folders) > 1 and not os.path.exists("%s%s" % (directory, folders[0])):
         os.makedirs("%s%s" % (directory, folders[0]))
-    fp = open('%s%s.markdown' % (directory, name), 'w')
+    fp = open('%s%s.%s' % (directory, name, markdown_extension), 'w')
 
     if meta_header:
         fp.write( unicode('<!-- Name: %s -->\n' % name) )

--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -98,7 +98,6 @@ if __name__ == "__main__":
         author = row[3]
         text = row[4]
         text = convert(text, '/wikis/')
-        time = ''
         try:
             time = datetime.datetime.fromtimestamp(time).strftime('%Y/%m/%d %H:%M:%S')
         except ValueError:

--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=python fileencoding=utf-8
 '''
 Copyright © 2013


### PR DESCRIPTION
Fixing up the markdown converter. I found it to have multiple issues, and could need some little improvement. Put each task in a separate commit just in case, so you can cherry-pick if you feel like :wink:

* the line setting the `time` variable to an empty string had the script crashing on me. Simply removing it worked fine.
* regardless whether a wiki page actually used a sub-directory, one with the name of the page was created (so one ended up with e.g. `WikiStart.markdown` and a `WikiStart` directory). Fixed that to only create directories if the page name really contained a slash.
* with `meta_header = True` (newly introduced variable) the pages' meta data are now written to the file as well (as comments). I just made that a variable at the head of the script instead of introducing a command-line option, to keep things simple.
* tired of always having to prefix the Python binary, I added a "shebang" line at the start of the script. Doesn't hurt in other context, but comes in handy when making the script executable :wink:
* added variable to make the markdown file extension configurable. Some folks (like me) prefer the shorter `.md`.