### PR TITLE
Gitlab 11.8 apiv4 fixes

### DIFF
--- a/gitlab_api/Connection.py
+++ b/gitlab_api/Connection.py
@@ -130,7 +130,7 @@ class Connection(object):
         if hasattr(new_issue, 'assignee'):
             new_issue.assignee_id = new_issue.assignee
         new_ticket = self.post_json("/projects/:id/issues", new_issue.__dict__, id=dest_project_id)
-        new_ticket_id  = new_ticket["id"]
+        new_ticket_id  = new_issue.iid
         # setting closed in create does not work -- limitation in gitlab
         if new_issue.state == 'closed': self.close_issue(dest_project_id,new_ticket_id)
         return Issues.create(new_ticket)

--- a/gitlab_api/Connection.py
+++ b/gitlab_api/Connection.py
@@ -101,7 +101,7 @@ class Connection(object):
         completed_url = self._complete_url(url_postfix, keywords)
         files = keywords['files'] if 'files' in keywords else None
         while True :
-            r = requests.post(completed_url, data = data, verify = self.verify, headers = self._request_headers(keywords), files = files)
+            r = requests.post(completed_url, data = data, verify = self.verify, files = files)
             if r.status_code < 500 :
                 break
             time.sleep(2)

--- a/gitlab_api/Connection.py
+++ b/gitlab_api/Connection.py
@@ -86,7 +86,7 @@ class Connection(object):
         :param keywords:  map, e.g. { "id" : 5 }
         :return: json of GET
         """
-        completed_url = self._complete_url(url_postfix, keywords)
+        completed_url = self._complete_url(url_postfix, keywords)+"&per_page=50"
         r = requests.get(completed_url, verify=self.verify)
         json = r.json()
         return json

--- a/gitlab_api/Connection.py
+++ b/gitlab_api/Connection.py
@@ -162,7 +162,6 @@ class Connection(object):
            r = self.upload_file(project_id, note.author, note.attachment_name, binary_attachment)
            relative_path_start_index = r['markdown'].index('/')
            relative_path = r['markdown'][:relative_path_start_index] + '..' + r['markdown'][relative_path_start_index:]
-           #note.note = "Attachment added: " + r['markdown'] + '\n\n' + note.note
            note.note = "Attachment added: " + relative_path + '\n\n' + note.note
            if origname != note.attachment_name :
                note.note += '\nFilename changed during trac to gitlab conversion. Original filename: ' + origname

--- a/migrate.py
+++ b/migrate.py
@@ -355,7 +355,7 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
                     dest.ensure_label(dest_project_id, 'vendor', labelcolor['vendor'])
 
                 if newstate == 'closed' :
-                    dest.close_issue(dest_project_id,new_ticket.id);
+                    dest.close_issue(dest_project_id,new_ticket.iid);
 
                 dest.comment_issue(dest_project_id, new_ticket, Notes(note = 'Changing status from ' + change[3] + ' to ' + change[4] + '.', created_at = change_time, author = author), binary_attachment)
 

--- a/migrate.py
+++ b/migrate.py
@@ -146,6 +146,7 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
     milestone_map_id={}
 
     if migrate_milestones:
+        milestone_id=0;
         for milestone_name in source.ticket.milestone.getAll():
             milestone = source.ticket.milestone.get(milestone_name)
             print(milestone)
@@ -159,7 +160,12 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
             if milestone['due']:
                 new_milestone.due_date = convert_xmlrpc_datetime(milestone['due'])
             new_milestone = dest.create_milestone(dest_project_id, new_milestone)
-            milestone_map_id[milestone_name] = new_milestone.id
+            if new_milestone.id:
+                milestone_map_id[milestone_name] = new_milestone.id
+                milestone_id = new_milestone.id + 1;
+            else:
+                milestone_map_id[milestone_name] = milestone_id;
+                milestone_id = milestone_id + 1;
 
     get_all_tickets = xmlrpclib.MultiCall(source)
 

--- a/migrate.py
+++ b/migrate.py
@@ -374,6 +374,13 @@ def convert_wiki(source, dest, dest_project_id):
             if (name == 'WikiStart'):
                 name = 'home'
             converted = trac2down.convert(page, os.path.dirname('/wikis/%s' % name))
+            try:
+                wikiauthor = dest.get_user_id(users_map[info['author']])
+                if wikiauthor == None:
+                       wikiauthor = dest.get_user_id(default_user)
+            except KeyError:
+                wikiauthor = dest.get_user_id(default_user)
+            dest.create_wiki(dest_project_id, converted, name, wikiauthor)
             if method == 'direct':
                 for attachment in source.wiki.listAttachments(name):
                     print(attachment)

--- a/migrate.py
+++ b/migrate.py
@@ -272,7 +272,8 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
                 new_issue.iid = src_ticket_id
             else:
                 new_issue.iid = dest.get_issues_iid(dest_project_id)
-
+        # Set correct issue id
+        new_issue.iid = src_ticket_id
         if 'milestone' in src_ticket_data:
             milestone = src_ticket_data['milestone']
             if milestone and milestone in milestone_map_id:

--- a/migrate.py
+++ b/migrate.py
@@ -92,7 +92,7 @@ if config.has_option('issues', 'component_filter'):
 add_label = None
 if config.has_option('issues', 'add_label'):
             add_label = config.get('issues', 'add_label')
-add_issue_header = config.getboolean('issues', 'add_header', fallback=False)
+add_issue_header = config.getboolean('issues', 'add_header')
 
 pattern_changeset = r'(?sm)In \[changeset:"([^"/]+?)(?:/[^"]+)?"\]:\n\{\{\{(\n#![^\n]+)?\n(.*?)\n\}\}\}'
 matcher_changeset = re.compile(pattern_changeset)

--- a/migrate.py
+++ b/migrate.py
@@ -250,7 +250,7 @@ def convert_issues(source, dest, dest_project_id, only_issues=None, blacklist_is
 
         # Minimal parameters
         new_issue = Issues(
-            title=src_ticket_data['summary'],
+            title=(src_ticket_data['summary'][:245] + '...') if len(src_ticket_data['summary']) > 245 else src_ticket_data['summary'],
             description=new_description,
             state=new_state,
             labels=",".join(new_labels)

--- a/trac2down/Trac2Down.py
+++ b/trac2down/Trac2Down.py
@@ -77,7 +77,10 @@ def save_file(text, name, version, date, author, directory):
     folders = name.rsplit("/", 1)
     if len(folders) > 1 and not os.path.exists("%s%s" % (directory, folders[0])):
         os.makedirs("%s%s" % (directory, folders[0]))
-    fp = open('%s%s.%s' % (directory, name, markdown_extension), 'w')
+    else:
+        if not os.path.exists('%s' % (directory)):
+            os.makedirs('%s' % (directory))
+    fp = open('%s%s.%s' % (directory, name, markdown_extension), "w+")
 
     if meta_header:
         fp.write( unicode('<!-- Name: %s -->\n' % name) )


### PR DESCRIPTION
Here are some fixes that made this script work again. I also merged some part of the project https://www.gams.com/~stefan/svn2git/ by @svigerske to extend some of the functionality currently provided. I tested it with gitlab 11.8 and the v4 gitlab api:

- Import the trac wiki to the gitlab project
- Add attachments to imported issues
- Correctly assign changes in the trac tickets to the gitlab issues (status changes, etc.)
- Do not crash on trac ticket titles longer than 255 characters